### PR TITLE
アイデア登録の実装

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::CategoriesController < ApplicationController
+  def create
+    category = Category.find_or_create_by!(category_params)
+    category.ideas.create!(idea_params)
+    render json: { status: "201" }
+  end
+
+  private
+
+    def category_params
+      params.permit(:name)
+    end
+
+    def idea_params
+      params.permit(:body)
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,7 @@ module IdeaManagement
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
     # Don't generate system test files.
     config.generators.system_tests = nil
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :categories, only: [:create]
+    end
+  end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :category do
-    name { "MyString" }
+    name { Faker::Color.color_name }
   end
 end

--- a/spec/factories/ideas.rb
+++ b/spec/factories/ideas.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :idea do
-    category { nil }
-    body { "MyText" }
+    category
+    body { Faker::Lorem.characters(number: 10) }
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,31 @@
 require "rails_helper"
 
 RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系" do
+    context "nameが一意のとき" do
+      let(:category) { build(:category) }
+      it "カテゴリーの作成に成功する" do
+        expect(category).to be_valid
+      end
+    end
+  end
+
+  describe "異常系" do
+    context "nameが空のとき" do
+      let(:category) { build(:category, name: nil) }
+      it "カテゴリーの作成に失敗する" do
+        expect(category).to be_invalid
+        expect(category.errors.details[:name][0][:error]).to eq :blank
+      end
+    end
+
+    context "nameが重複するとき" do
+      let!(:first_category) { create(:category, name: "青") }
+      let(:category) { build(:category, name: "青") }
+      it "カテゴリーの作成に失敗する" do
+        expect(category).to be_invalid
+        expect(category.errors.details[:name][0][:error]).to eq :taken
+      end
+    end
+  end
 end

--- a/spec/models/idea_spec.rb
+++ b/spec/models/idea_spec.rb
@@ -1,5 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Idea, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系" do
+    context "bodyが存在するとき" do
+      let(:idea) { build(:idea) }
+      it "アイデアの登録に成功する" do
+        expect(idea).to be_valid
+      end
+    end
+  end
+
+  describe "異常系" do
+    context "bodyが存在しないとき" do
+      let(:idea) { build(:idea, body: nil) }
+      it "作成に失敗する" do
+        expect(idea).to be_invalid
+        expect(idea.errors.details[:body][0][:error]).to eq :blank
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -25,5 +25,12 @@ RSpec.describe "Api::V1::Categories", type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    context "カテゴリーが空のとき" do
+      let(:params) { attributes_for(:category, name: nil).merge(attributes_for(:idea)) }
+      it "作成に失敗する" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -26,8 +26,22 @@ RSpec.describe "Api::V1::Categories", type: :request do
       end
     end
 
+    context "全情報がから無いとき" do
+      let(:params) { attributes_for(:category, name: nil).merge(attributes_for(:idea, body: nil)) }
+      it "作成に失敗する" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
     context "カテゴリーが空のとき" do
       let(:params) { attributes_for(:category, name: nil).merge(attributes_for(:idea)) }
+      it "作成に失敗する" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context "bodyが空欄のとき" do
+      let(:params) { attributes_for(:category).merge(attributes_for(:idea, body: nil)) }
       it "作成に失敗する" do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
       end

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -3,16 +3,27 @@ require "rails_helper"
 RSpec.describe "Api::V1::Categories", type: :request do
   describe "POST /api/v1/categories" do
     subject { post(api_v1_categories_path, params: params) }
+
     context "nameとbodyに必要な情報が存在するとき" do
       let(:params) { attributes_for(:category).merge(attributes_for(:idea)) }
       it "カテゴリーとアイデアの作成に成功する" do
-        expect{ subject }.to change {Idea.count}.by(1)
+        expect { subject }.to change { Idea.count }.by(1)
         res = JSON.parse(response.body)
         expect(res["status"]).to eq "201"
         expect(response).to have_http_status(:ok)
       end
     end
 
-
+    context "カテゴリーが既に存在するとき" do
+      let!(:category) { create(:category, name: "既存カテゴリー") }
+      let(:params) { attributes_for(:category, name: "既存カテゴリー").merge(attributes_for(:idea)) }
+      it "アイデアだけ作成される" do
+        expect { subject }.to change { Idea.count }.by(1) &
+                              not_change { Category.count }
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "201"
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Categories", type: :request do
+  describe "POST /api/v1/categories" do
+    subject { post(api_v1_categories_path, params: params) }
+    context "nameとbodyに必要な情報が存在するとき" do
+      let(:params) { attributes_for(:category).merge(attributes_for(:idea)) }
+      it "カテゴリーとアイデアの作成に成功する" do
+        expect{ subject }.to change {Idea.count}.by(1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "201"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
+  RSpec::Matchers.define_negated_matcher :not_change, :change
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods


### PR DESCRIPTION
close #4 

## 実装内容
- カテゴリーとアイデアの登録機能の実装
- カテゴリー作成時は新規の物だけ作成する
- 登録機能のリクエストテストを実装