### PR TITLE
アイデア取得APIの実装

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -29,10 +29,10 @@ class Api::V1::CategoriesController < ApplicationController
 
     def format(item)
       {
-        "id": item.id.to_s,
-        "category": item.category.name.to_s,
-        "body": item.body.to_s,
-        "created_at": item.created_at.to_i.to_s,
+        "id": item.id,
+        "category": item.category.name,
+        "body": item.body,
+        "created_at": item.created_at.to_i,
       }
     end
 

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -5,7 +5,42 @@ class Api::V1::CategoriesController < ApplicationController
     render json: { status: "201" }
   end
 
+  def index
+    category_word = Category.where(name: params[:name])
+    result = Idea.find_by(category_id: category_word.ids)
+    no_match = Idea.order(created_at: :asc).includes(:category)
+
+    if result
+      render json: match_result(result)
+    else
+      render json: not_match_result(no_match)
+    end
+  end
+
   private
+
+    def not_match_result(not_match_items)
+      not_match_items.map do |item|
+        format(item)
+      end
+    end
+
+    def match_result(match_item)
+      format(match_item)
+    end
+
+    def format(item)
+      {
+        "data": [
+          {
+            "id": item.id.to_s,
+            "category": item.category.name.to_s,
+            "body": item.body.to_s,
+            "created_at": item.created_at.to_i.to_s,
+          },
+        ],
+      }
+    end
 
     def category_params
       params.permit(:name)

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -7,38 +7,32 @@ class Api::V1::CategoriesController < ApplicationController
 
   def index
     category_word = Category.where(name: params[:name])
-    result = Idea.find_by(category_id: category_word.ids)
-    no_match = Idea.order(created_at: :asc).includes(:category)
+    result = Idea.where(category_id: category_word.ids).includes(:category)
 
-    if result
-      render json: match_result(result)
+    if result.any?
+      render json: { data: match_result(result) }
+    elsif params[:name].blank?
+      no_match = Idea.order(created_at: :asc).includes(:category)
+      render json: { data: match_result(no_match) }
     else
-      render json: not_match_result(no_match)
+      render json: { status: "404" }
     end
   end
 
   private
 
-    def not_match_result(not_match_items)
-      not_match_items.map do |item|
+    def match_result(match_items)
+      match_items.map do |item|
         format(item)
       end
     end
 
-    def match_result(match_item)
-      format(match_item)
-    end
-
     def format(item)
       {
-        "data": [
-          {
-            "id": item.id.to_s,
-            "category": item.category.name.to_s,
-            "body": item.body.to_s,
-            "created_at": item.created_at.to_i.to_s,
-          },
-        ],
+        "id": item.id.to_s,
+        "category": item.category.name.to_s,
+        "body": item.body.to_s,
+        "created_at": item.created_at.to_i.to_s,
       }
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :categories, only: [:create]
+      resources :categories, only: [:create, :index]
     end
   end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -76,3 +76,7 @@ RSpec/ReturnFromStub:
 # context ごとに let! を使い分けたい場合があるため無効に
 RSpec/LetSetup:
   Enabled: false
+
+# let等の使用上限回数を5から10に変更
+RSpec/MultipleMemoizedHelpers:
+  Max: 10

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :category do
-    name { Faker::Color.color_name }
+    sequence(:name) { |n| "#{n}_#{Faker::Color.color_name}" }
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :category do
-    sequence(:name) { |n| "#{n}_#{Faker::Color.color_name}" }
+    sequence(:name) {|n| "#{n}_#{Faker::Color.color_name}" }
   end
 end

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Api::V1::Categories", type: :request do
       end
     end
 
-    context "全情報がから無いとき" do
+    context "全情報が空欄のとき" do
       let(:params) { attributes_for(:category, name: nil).merge(attributes_for(:idea, body: nil)) }
       it "作成に失敗する" do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
@@ -44,6 +44,39 @@ RSpec.describe "Api::V1::Categories", type: :request do
       let(:params) { attributes_for(:category).merge(attributes_for(:idea, body: nil)) }
       it "作成に失敗する" do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
+  describe "GET /api/v1/categories" do
+    subject { get(api_v1_categories_path, params: params) }
+
+    let!(:ideas) { create_list(:idea, idea_count) }
+    let(:idea_count) { 4 }
+    context "検索したカテゴリーのアイテムが存在する時" do
+      let!(:category_item) { create(:category) }
+      let!(:idea1) { create(:idea, category: category_item) }
+      let!(:idea2) { create(:idea, category: category_item) }
+      let!(:idea3) { create(:idea, category: category_item) }
+      let(:params) { attributes_for(:category, name: category_item.name) }
+      it "指定したカテゴリーを持つアイデア一覧を返す" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(res["data"].count).to eq 3
+        expect(res["data"][0].keys).to eq ["id", "category", "body", "created_at"]
+        expect(res["data"][0]["category"]).to eq params[:name]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "リクエストが空のとき" do
+      it "登録されているアイデアの一覧を返す" do
+      end
+    end
+
+    context "リクエストしたカテゴリーが存在しないとき" do
+      it "404を返す" do
       end
     end
   end

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -86,7 +86,13 @@ RSpec.describe "Api::V1::Categories", type: :request do
     end
 
     context "リクエストしたカテゴリーが存在しないとき" do
+      let(:params) { attributes_for(:category) }
       it "404を返す" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(res["status"]).to eq "404"
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/requests/api/v1/categories_spec.rb
+++ b/spec/requests/api/v1/categories_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe "Api::V1::Categories", type: :request do
   describe "GET /api/v1/categories" do
     subject { get(api_v1_categories_path, params: params) }
 
-    let!(:ideas) { create_list(:idea, idea_count) }
-    let(:idea_count) { 4 }
+    let!(:ideas) { create_list(:idea, ideas_count) }
+    let(:ideas_count) { 4 }
     context "検索したカテゴリーのアイテムが存在する時" do
       let!(:category_item) { create(:category) }
       let!(:idea1) { create(:idea, category: category_item) }
@@ -71,7 +71,17 @@ RSpec.describe "Api::V1::Categories", type: :request do
     end
 
     context "リクエストが空のとき" do
-      it "登録されているアイデアの一覧を返す" do
+      let(:params) { nil }
+      let(:first_idea) { ideas.first }
+      it "登録されている全アイデアを一覧で返す" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(res["data"].count).to eq ideas_count
+        expect(res["data"][0].keys).to eq ["id", "category", "body", "created_at"]
+        expect(res["data"][0]["body"]).to eq first_idea.body
+        expect(res["data"][0]["created_at"]).to eq first_idea.created_at.to_i
+        expect(response).to have_http_status(:ok)
       end
     end
 


### PR DESCRIPTION
close #5 

## 実装内容
- アイデア取得のAPIを作成
  - リクエスト内容と一致する時、対象のアイデア一覧を返す
  - リクエストが空欄の時、登録されている全件のアイデアを返す
  - リクエストに一致しない時、`404`を返す
- 上記の取得時のテストを`RSpec`にて実装